### PR TITLE
substitute GitLab icons for GitHub ones

### DIFF
--- a/faq.html
+++ b/faq.html
@@ -57,7 +57,7 @@
 <li><a href="https://twitter.com/butterproject" title="Twitter" target="_blank" class="twitter">Twitter</a></li>
 <li><a href="https://www.facebook.com/ButterProjectOrg" title="Facebook" target="_blank" class="facebook">Facebook</a></li>
 <li><a href="https://www.reddit.com/r/ButterProject/" title="Reddit" target="_blank" class="reddit">Reddit</a></li>
-<li><a href="https://github.com/butterproject/" title="GitLab" target="_blank" class="gitlab">GitLab</a></li>
+<li><a href="https://github.com/butterproject/" title="GitHub" target="_blank" class="github">GitHub</a></li>
 			</ul>
 
 			<ul class="align-left">
@@ -171,7 +171,7 @@
 <li><a href="https://twitter.com/butterproject" title="Twitter" target="_blank" class="twitter">Twitter</a></li>
 <li><a href="https://www.facebook.com/ButterProjectOrg" title="Facebook" target="_blank" class="facebook">Facebook</a></li>
 <li><a href="https://www.reddit.com/r/ButterProject/" title="Reddit" target="_blank" class="reddit">Reddit</a></li>
-<li><a href="https://github.com/butterproject/" title="GitLab" target="_blank" class="gitlab">GitLab</a></li>
+<li><a href="https://github.com/butterproject/" title="GitHub" target="_blank" class="github">GitHub</a></li>
                 </ul>
             </nav>
             <footer>

--- a/index.html
+++ b/index.html
@@ -57,7 +57,7 @@
 <li><a href="https://twitter.com/butterproject" title="Twitter" target="_blank" class="twitter">Twitter</a></li>
 <li><a href="https://www.facebook.com/ButterProjectOrg" title="Facebook" target="_blank" class="facebook">Facebook</a></li>
 <li><a href="https://www.reddit.com/r/ButterProject/" title="Reddit" target="_blank" class="reddit">Reddit</a></li>
-<li><a href="https://github.com/butterproject/" title="GitLab" target="_blank" class="gitlab">GitLab</a></li>
+<li><a href="https://github.com/butterproject/" title="GitHub" target="_blank" class="github">GitHub</a></li>
 			</ul>
 
 			<ul class="align-left">
@@ -277,7 +277,7 @@
 <li><a href="https://twitter.com/butterproject" title="Twitter" target="_blank" class="twitter">Twitter</a></li>
 <li><a href="https://www.facebook.com/ButterProjectOrg" title="Facebook" target="_blank" class="facebook">Facebook</a></li>
 <li><a href="https://www.reddit.com/r/ButterProject/" title="Reddit" target="_blank" class="reddit">Reddit</a></li>
-<li><a href="https://github.com/butterproject/" title="GitLab" target="_blank" class="gitlab">GitLab</a></li>
+<li><a href="https://github.com/butterproject/" title="GitHub" target="_blank" class="github">GitHub</a></li>
                 </ul>
             </nav>
             <footer>

--- a/tos.html
+++ b/tos.html
@@ -84,7 +84,7 @@
 <li><a href="https://twitter.com/butterproject" title="Twitter" target="_blank" class="twitter">Twitter</a></li>
 <li><a href="https://www.facebook.com/ButterProjectOrg" title="Facebook" target="_blank" class="facebook">Facebook</a></li>
 <li><a href="https://www.reddit.com/r/ButterProject/" title="Reddit" target="_blank" class="reddit">Reddit</a></li>
-<li><a href="https://github.com/butterproject/" title="GitLab" target="_blank" class="gitlab">GitLab</a></li>
+<li><a href="https://github.com/butterproject/" title="GitHub" target="_blank" class="github">GitHub</a></li>
                 </ul>
             </nav>
             <footer>


### PR DESCRIPTION
The page is showing GitLab icons instead of GitHub ones, I believe this is due the fact that PopcorTime uses GitLab.