### PR TITLE
Update discussion forum link from TODO page to point to new discussion page

### DIFF
--- a/src/faq.html
+++ b/src/faq.html
@@ -94,7 +94,7 @@
 			
 			<article id="other-question">
 				<h2>I have a question that is not listed here, were should I go?</h2>
-				<p>You could ask your question on <a href="https://butterproject.github.io/butter/discuss">our forum</a>, that's where our developers are trying to answer every question. And when they don't have time to help you, someone else from our community might be able to point you in the right direction.</p>
+				<p>You could ask your question on <a href="http://discuss.butterproject.org/">our forum</a>, that's where our developers are trying to answer every question. And when they don't have time to help you, someone else from our community might be able to point you in the right direction.</p>
 			</article>
 		</section>
 	</div>


### PR DESCRIPTION
Previous link (https://butterproject.github.io/butter/discuss) contains only "TODO.
New link (from project Twitter) is http://discuss.butterproject.org/.
